### PR TITLE
Add desc indexes to optimize desc query

### DIFF
--- a/docker-compose.gatling.yml
+++ b/docker-compose.gatling.yml
@@ -40,6 +40,7 @@ services:
       - 5432:5432
     networks:
       - fide_api
+    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all
     restart: unless-stopped
     deploy:
       resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     container_name: fide_postgres
     volumes:
       - ./.containers_data/postgres:/var/lib/postgresql/data
+    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all
     environment:
       POSTGRES_DB: fide
       POSTGRES_USER: admin

--- a/modules/db/src/main/resources/db/migration/V0009__add_desc_index.sql
+++ b/modules/db/src/main/resources/db/migration/V0009__add_desc_index.sql
@@ -1,0 +1,21 @@
+-- Add desc indexes for players
+CREATE INDEX players_name_desc_idx ON players(name DESC NULLS LAST);
+CREATE INDEX players_standard_desc_idx ON players(standard DESC NULLS LAST);
+CREATE INDEX players_rapid_desc_idx ON players(rapid DESC NULLS LAST);
+CREATE INDEX players_blitz_desc_idx ON players(blitz DESC NULLS LAST);
+
+-- Add desc indexes for federations_summary
+CREATE INDEX fed_sum_avg_rating_desc_idx ON federations_summary(avg_rating DESC NULLS LAST);
+CREATE INDEX fed_sum_avg_standard_desc_idx ON federations_summary(avg_standard DESC NULLS LAST);
+CREATE INDEX fed_sum_avg_rapid_desc_idx ON federations_summary(avg_rapid DESC NULLS LAST);
+CREATE INDEX fed_sum_avg_blitz_desc_idx ON federations_summary(avg_blitz DESC NULLS LAST);
+CREATE INDEX fed_sum_avg_top_standard_desc_idx ON federations_summary(avg_top_standard DESC NULLS LAST);
+CREATE INDEX fed_sum_avg_top_rapid_desc_idx ON federations_summary(avg_top_rapid DESC NULLS LAST);
+CREATE INDEX fed_sum_avg_top_blitz_desc_idx ON federations_summary(avg_top_blitz DESC NULLS LAST);
+CREATE INDEX fed_sum_avg_top_standard_rank_desc_idx ON federations_summary(avg_top_standard_rank DESC NULLS LAST);
+CREATE INDEX fed_sum_avg_top_rapid_rank_desc_idx ON federations_summary(avg_top_rapid_rank DESC NULLS LAST);
+CREATE INDEX fed_sum_avg_top_blitz_rank_desc_idx ON federations_summary(avg_top_blitz_rank DESC NULLS LAST);
+CREATE INDEX fed_sum_standard_players_desc_idx ON federations_summary(standard_players DESC NULLS LAST);
+CREATE INDEX fed_sum_rapid_players_desc_idx ON federations_summary(rapid_players DESC NULLS LAST);
+CREATE INDEX fed_sum_blitz_players_desc_idx ON federations_summary(blitz_players DESC NULLS LAST);
+CREATE INDEX fed_sum_players_desc_idx ON federations_summary(players DESC NULLS LAST);


### PR DESCRIPTION
We have stress testing, therefore We could find performance issue like this.
With the tests, I noticed a significant performance dropped on some query (look at warmup tests before image), then after some search the fix is quite easy: It just needs some more indexes in our database.

With this small changes the improve in performance is staggering.
With `Stress Simulation` test, the at 99% tile, it is 2000% faster and 3000% time faster in `mean` value.

With `Capacity Simulation` test, the failed requests are reduce from 81% to 0%, and there is almost no different between 0 rps and 240 rps.

So, these stress tests are meaningless now, I'll increase load for these stress tests in another PR.

Screenshot of the results before and after:

Before:
<img width="1012" alt="Screenshot 2024-04-28 at 08 38 11" src="https://github.com/lenguyenthanh/fide/assets/437967/5476051e-805d-4a52-80e6-b6449442493a">

After:
<img width="1026" alt="Screenshot 2024-04-28 at 08 51 56" src="https://github.com/lenguyenthanh/fide/assets/437967/725164e7-76de-4233-866a-f9e54bce4abb">

Before:
<img width="1026" alt="Screenshot 2024-04-28 at 08 36 58" src="https://github.com/lenguyenthanh/fide/assets/437967/41f61d56-1a56-4785-a778-139e3850582c">

After:
<img width="1039" alt="Screenshot 2024-04-28 at 08 16 00" src="https://github.com/lenguyenthanh/fide/assets/437967/1692400d-10bc-4fe0-bdfd-e5a2ee614a17">

Before:
<img width="1038" alt="Screenshot 2024-04-28 at 08 42 38" src="https://github.com/lenguyenthanh/fide/assets/437967/d8f992e0-2346-4632-b5c5-7ee92cbf0a00">

After:
<img width="1036" alt="Screenshot 2024-04-28 at 08 55 00" src="https://github.com/lenguyenthanh/fide/assets/437967/716b0e81-c097-40f2-8d02-a9b7c0c805bb">