### PR TITLE
Remove log4cats noop dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,6 @@ val commonSettings = Seq(
     catsEffect,
     fs2,
     log4Cats,
-    log4CatsNoop,
     weaver,
     weaverScalaCheck
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,8 +42,6 @@ object Dependencies {
 
   val ducktape = "io.github.arainko" %% "ducktape" % "0.2.0"
 
-  val log4CatsNoop = "org.typelevel" %% "log4cats-noop" % "2.7.0" % Test
-
   val gatlingTestFramework = "io.gatling"            % "gatling-test-framework"    % V.gatling % Test
   val gatlingHighCharts    = "io.gatling.highcharts" % "gatling-charts-highcharts" % V.gatling % Test
 


### PR DESCRIPTION
As it is moved to core module:
https://github.com/typelevel/log4cats/pull/778