### PR TITLE
Fix query syntax when isActive = true

### DIFF
--- a/modules/db/src/main/scala/Db.scala
+++ b/modules/db/src/main/scala/Db.scala
@@ -218,15 +218,14 @@ private object Sql:
 
     val f = filter.isActive.fold(bw): x =>
       val a = filterActive(x)
-      bw.fold(a)(_ |+| a).some
+      bw.fold(a)(_ |+| and |+| a).some
 
     filter.federationId.fold(f): x =>
       val a = federationIdFragment(x)
-      f.fold(a)(_ |+| a).some
+      f.fold(a)(_ |+| and |+| a).some
 
   private lazy val filterActive: Fragment[Boolean] =
-    sql"""
-        AND p.active = $bool"""
+    sql"p.active = $bool"
 
   private lazy val insertIntoPlayer =
     sql"INSERT INTO players (id, name, title, women_title, other_titles, standard, rapid, blitz, sex, birth_year, active, federation_id)"
@@ -249,8 +248,7 @@ private object Sql:
         LIMIT ${int4} OFFSET ${int4}""".apply(page.limit, page.offset)
 
   private def federationIdFragment(id: FederationId): AppliedFragment =
-    sql"""
-        AND p.federation_id = $text""".apply(id)
+    sql"""p.federation_id = $text""".apply(id)
 
   private def sortingFragment(sorting: Sorting): AppliedFragment =
     val column  = s"p.${sorting.sortBy.value}"


### PR DESCRIPTION
`ServerInternalError` was thrown for this
```
curl -X 'GET' \
  'http://localhost:9669/api/players?sort_by=standard&order_by=desc&is_active=true&name=magnus%20carlsen&page=1&page_size=30' \
  -H 'accept: application/json'
```
with stacktrace:
```
[info] 🔥
[info] 🔥  Postgres ERROR 42601 raised in scanner_yyerror (scan.l:1241)
[info] 🔥
[info] 🔥    Problem: Syntax error at or near "AND".
[info] 🔥
[info] 🔥  The statement under consideration was defined
[info] 🔥    at /Users/tle/git/lichess/fide/modules/db/src/main/scala/Db.scala:262
[info] 🔥
[info] 🔥      SELECT p.id, p.name, p.title, p.women_title, p.other_titles, p.standard, p.rapid, p.blitz, p.sex, p.birth_year, p.active, p.updated_at, p.created_at, f.id, f.name
[info] 🔥      FROM players AS p LEFT JOIN federations AS f ON p.federation_id = f.id
[info] 🔥    WHERE
[info] 🔥      AND p.active = $1
[info] 🔥      └─── Syntax error at or near "AND".
[info] 🔥      ORDER BY p.birth_year ASC NULLS LAST
[info] 🔥      LIMIT $2 OFFSET $3
[info] 🔥
[info] 🔥  If this is an error you wish to trap and handle in your application, you can do
[info] 🔥  so with a SqlState extractor. For example:
[info] 🔥
[info] 🔥    doSomething.recoverWith { case SqlState.SyntaxError(ex) =>  ...}
[info] 🔥
[info] skunk.exception.PostgresErrorException: Syntax error at or near "AND".
```