### PR TITLE
Bump cats 2.11.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
 
   def http4s(artifact: String) = "org.http4s" %% s"http4s-$artifact" % V.http4s
 
-  val catsCore   = "org.typelevel" %% "cats-core"   % "2.10.0"
+  val catsCore   = "org.typelevel" %% "cats-core"   % "2.11.0"
   val catsEffect = "org.typelevel" %% "cats-effect" % V.catsEffect
 
   val fs2         = "co.fs2"  %% "fs2-core"           % V.fs2


### PR DESCRIPTION
We use this one as it aligns with cats-effect which both depends on scala native `0.4`