### PR TITLE
Save unknown federations to database

### DIFF
--- a/modules/crawler/src/main/scala/Downloader.scala
+++ b/modules/crawler/src/main/scala/Downloader.scala
@@ -33,7 +33,7 @@ object Downloader:
         .through(fs2.text.lines)
         .drop(1) // first line is header
         .evalMap(parseLine)
-        .collect { case Some(x) => x }
+        .unNone
 
   def parseLine(line: String): Logger[IO] ?=> IO[Option[(NewPlayer, Option[NewFederation])]] =
 

--- a/modules/crawler/src/main/scala/Downloader.scala
+++ b/modules/crawler/src/main/scala/Downloader.scala
@@ -16,6 +16,7 @@ trait Downloader:
 
 object Downloader:
   val downloadUrl = uri"http://ratings.fide.com/download/players_list.zip"
+  val currentYear = java.time.Year.now.getValue
 
   lazy val request = Request[IO](
     method = Method.GET,
@@ -66,7 +67,7 @@ object Downloader:
       wTitle       = string(89, 94) >>= Title.apply
       otherTitles  = string(94, 109).fold(Nil)(OtherTitle.applyToList)
       sex          = string(79, 82) >>= Sex.apply
-      year         = number(152, 156).filter(_ > 1000)
+      year         = number(152, 156).filter(y => y > 1000 && y < currentYear)
       inactiveFlag = string(158, 160).filter(_.contains("i"))
       federationId = string(76, 79) >>= FederationId.option
     yield NewPlayer(

--- a/modules/crawler/src/test/scala/DownloaderTest.scala
+++ b/modules/crawler/src/test/scala/DownloaderTest.scala
@@ -23,5 +23,5 @@ object DownloaderTest extends SimpleIOSuite:
           .fold[Set[FederationId]](Set.empty)((acc, x) => acc ++ x.map(_.id))
           .compile
           .last
-          .map(x => Federation.names.keySet.diff(x.get))
+          .map(x => Federation.all.keySet.diff(x.get))
           .map(x => expect(x == Set.empty))

--- a/modules/crawler/src/test/scala/DownloaderTest.scala
+++ b/modules/crawler/src/test/scala/DownloaderTest.scala
@@ -19,9 +19,9 @@ object DownloaderTest extends SimpleIOSuite:
       .build
       .use: client =>
         Downloader(client).fetch
-          .map(x => x._2)
-          .fold[Set[FederationId]](Set.empty)((acc, x) => acc ++ x.map(_.id))
+          .map(x => x._2.map(_.id))
+          .unNone
           .compile
-          .last
-          .map(x => Federation.all.keySet.diff(x.get))
+          .to(Set)
+          .map(Federation.all.keySet.diff)
           .map(x => expect(x == Set.empty))

--- a/modules/crawler/src/test/scala/ParserTest.scala
+++ b/modules/crawler/src/test/scala/ParserTest.scala
@@ -31,4 +31,4 @@ object ParserTest extends SimpleIOSuite:
       .map(_.flatten.map(_.active))
       .map(x => expect(x == List(false, false, true, true)))
 
-  private def parse(s: String) = Downloader.parse(s).map(_.map(_._1))
+  private def parse(s: String) = Downloader.parseLine(s).map(_.map(_._1))

--- a/modules/domain/src/main/scala/Domain.scala
+++ b/modules/domain/src/main/scala/Domain.scala
@@ -131,10 +131,12 @@ case class Federation(
 
 object Federation:
 
-  def nameById(id: FederationId): Option[String] = names.get(id)
+  def nameById(id: FederationId): Option[String] =
+    if id.value.toLowerCase == "non" then None
+    else all.get(id).orElse(id.value.some)
 
   import io.github.iltotore.iron.*
-  val names: Map[FederationId, String] = Map(
+  val all: Map[FederationId, String] = Map(
     FederationId("AFG") -> "Afghanistan",
     FederationId("AHO") -> "Netherlands Antilles",
     FederationId("ALB") -> "Albania",


### PR DESCRIPTION
If there are unknown federations, we still save it to database, so user could find them using api. This also silent warning for NON federation.