### PR TITLE
Add migration script for new rating validation

### DIFF
--- a/modules/db/src/main/resources/db/migration/V0010__force_crawling.sql
+++ b/modules/db/src/main/resources/db/migration/V0010__force_crawling.sql
@@ -1,0 +1,1 @@
+DELETE from cache where key='fide_last_update_key';


### PR DESCRIPTION
We updated the lower bound of rating to 1400, so we'll have some invalid data in exist database. This migration script'll force crawling data to update existing data with new valid one.