### PR TITLE
Golf: simplify matching options

### DIFF
--- a/modules/crawler/src/main/scala/Syncer.scala
+++ b/modules/crawler/src/main/scala/Syncer.scala
@@ -24,9 +24,7 @@ object Syncer:
     def apply(local: Option[String], remote: Option[String]): Status =
       (local, remote).match
         case (Some(l), Some(r)) if l == r => Status.UpToDate
-        case (Some(l), Some(r))           => Status.OutDated(r.some)
-        case (None, Some(r))              => Status.OutDated(r.some)
-        case (_, None)                    => Status.OutDated(none)
+        case _                            => Status.OutDated(remote)
 
   def instance(store: KVStore, client: Client[IO])(using Logger[IO]): Syncer =
     Syncer(store, UpdateChecker(client))


### PR DESCRIPTION
All but first arms returns value that equal to right part of the matched tuple, which is just `remote`.

Another options would be to rewrite it as:

~~~scala
if (local zip remote).exists(_ == _)
then Status.UpToDate
else Status.Outdated(remote)
~~~

Possible tweaks:

- `Eq.eqv` instead of `(_ == _)`

- Scala 2 stylish if-expession
