### PR TITLE
Ship native CLI binaries + Alpine image like dumbo

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -8,6 +8,8 @@ on:
 # Native link is memory-hungry; give the forked sbt JVM a large heap.
 env:
   SBT_OPTS: -Xmx6g -Xss8m
+  # Match dumbo's release build: smaller, faster binaries.
+  SCALANATIVE_MODE: release-fast
 
 jobs:
   native-cli:
@@ -55,11 +57,81 @@ jobs:
           bin=$(ls modules/cli/native/target/scala-*/cli)
           cp "$bin" "fide-cli-${{ matrix.suffix }}"
           chmod +x "fide-cli-${{ matrix.suffix }}"
+          # Ship a zip alongside the bare binary, like dumbo.
+          zip -j "fide-cli-${{ matrix.suffix }}.zip" "fide-cli-${{ matrix.suffix }}"
 
-      - name: Smoke-test binary
+      # The binary is dynamically linked against the brew TLS libs (s2n, utf8proc,
+      # openssl@3's libcrypto), so the loader needs them on its path. On Linux the
+      # keg-only openssl@3 lives under opt/openssl@3/lib; on macOS brew --prefix/lib
+      # covers s2n/utf8proc and the openssl@3 keg is resolved via its install name.
+      - name: Smoke-test binary (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          brew="/home/linuxbrew/.linuxbrew"
+          export LD_LIBRARY_PATH="$brew/lib:$brew/opt/openssl@3/lib:$LD_LIBRARY_PATH"
+          ./fide-cli-${{ matrix.suffix }} --help
+
+      - name: Smoke-test binary (macOS)
+        if: runner.os == 'macOS'
         run: ./fide-cli-${{ matrix.suffix }} --help
 
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:
-          files: fide-cli-${{ matrix.suffix }}
+          files: |
+            fide-cli-${{ matrix.suffix }}
+            fide-cli-${{ matrix.suffix }}.zip
+
+  # Self-contained deliverable: an Alpine image with the TLS libs provisioned via apk
+  # and gcompat (the binary is a glibc binary built on the Ubuntu runner). Mirrors
+  # rolang/dumbo's docker-build approach.
+  native-cli-docker:
+    name: native-cli-docker
+    needs: native-cli
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup JVM
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: sbt
+
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Install Scala Native dependencies
+        uses: ./.github/actions/setup-scala-native
+
+      - name: Build native CLI binary
+        run: sbt cliNative/nativeLink
+
+      - name: Stage binary for Docker build
+        run: |
+          bin=$(ls modules/cli/native/target/scala-*/cli)
+          cp "$bin" docker-build/fide-cli-linux-x86_64
+          chmod +x docker-build/fide-cli-linux-x86_64
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build, smoke-test and push Alpine image
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          image="ghcr.io/${{ github.repository }}/fide-cli-native"
+          docker build ./docker-build -t "$image:$tag-alpine"
+          docker run --rm "$image:$tag-alpine" --help   # smoke test
+          docker tag "$image:$tag-alpine" "$image:latest-alpine"
+          docker push "$image:$tag-alpine"
+          docker push "$image:latest-alpine"

--- a/README.md
+++ b/README.md
@@ -121,6 +121,29 @@ docker compose up -d
 
 You can use the pre-built CLI Docker image from [GitHub Container Registry](https://github.com/lenguyenthanh/fide/pkgs/container/fide-cli) to ingest historical CSV files into the database.
 
+### Native CLI binary
+
+Each release also ships standalone Scala Native binaries (`fide-cli-<os>-<arch>`,
+also as `.zip`) on the [Releases page](https://github.com/lenguyenthanh/fide/releases),
+for `linux-x86_64`, `linux-aarch64`, `macos-x86_64` and `macos-aarch64`.
+
+These binaries are **dynamically linked** against the TLS stack used for the
+PostgreSQL connection — `s2n-tls`, `utf8proc`, and OpenSSL's `libcrypto.so.3` —
+so those libraries must be present at runtime. Install them with your package
+manager:
+
+- **Arch:** `sudo pacman -S s2n-tls libutf8proc openssl`
+- **Alpine:** `apk add gcompat libgcc libstdc++ s2n-tls utf8proc libcrypto3`
+- **Ubuntu/Debian:** `s2n-tls` is not packaged, so install via
+  [Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux)
+  (`brew install s2n utf8proc openssl@3`) and point the loader at it:
+  `export LD_LIBRARY_PATH="$(brew --prefix)/lib:$(brew --prefix openssl@3)/lib"`.
+- **macOS:** `brew install s2n utf8proc openssl@3`
+
+If you'd rather not manage these dependencies, use a Docker image instead — either
+the JVM image below, or the self-contained native Alpine image
+`ghcr.io/lenguyenthanh/fide/fide-cli-native:latest-alpine` (TLS libs preinstalled).
+
 ### CSV Format
 
 The CLI expects CSV files from [fide-rating-database](https://github.com/lenguyenthanh/fide-rating-database) with the following 16-column format:

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,0 +1,21 @@
+# Self-contained Alpine image for the native fide-cli.
+#
+# The binary is a glibc binary linked on the Ubuntu CI runner, so Alpine needs
+# `gcompat` (glibc compatibility shim) plus the TLS stack the Scala Native build
+# links against: s2n-tls, utf8proc, and openssl's libcrypto.so.3 (libcrypto3).
+# Mirrors rolang/dumbo's docker-build, with libcrypto3 added because our s2n keg
+# links openssl@3 (dumbo's s2n self-links its crypto).
+FROM alpine:latest
+
+RUN apk update && apk add --no-cache \
+      gcompat \
+      libgcc \
+      libstdc++ \
+      s2n-tls \
+      utf8proc \
+      libcrypto3
+
+ADD --chmod=+x fide-cli-linux-x86_64 /usr/local/bin/fide-cli
+
+ENTRYPOINT ["/usr/local/bin/fide-cli"]
+CMD ["--help"]


### PR DESCRIPTION
The published native CLI binary is dynamically linked against the brew TLS
stack (s2n, utf8proc, openssl@3's libcrypto.so.3), so it can't run without
those libs on the loader path — which is why the v0.2.1 release smoke test
failed on Linux with "libutf8proc.so.3: cannot open shared object file".

Following rolang/dumbo's approach for shipping a Skunk-based native CLI:

- native-release.yml: set LD_LIBRARY_PATH (incl. keg-only openssl@3) before
  the Linux smoke test; build with SCALANATIVE_MODE=release-fast; ship a .zip
  alongside the bare binary; add a native-cli-docker job that builds, smoke-
  tests and pushes a self-contained Alpine image.
- docker-build/Dockerfile: Alpine + gcompat + s2n-tls/utf8proc/libcrypto3
  (libcrypto3 added vs dumbo because our s2n keg links openssl@3 rather than
  self-linking crypto).
- README: document the native binaries and their per-distro runtime deps.

Validated end-to-end on this branch (temporary triggers since reverted): all
Linux/macOS-aarch64 legs link + smoke-test green, and the Alpine image builds
and runs `fide-cli --help` via gcompat with apk-provided TLS libs.
